### PR TITLE
Add custom section encoding and decoding

### DIFF
--- a/binary/custom.go
+++ b/binary/custom.go
@@ -1,0 +1,22 @@
+package binary
+
+import (
+	"bytes"
+
+	"github.com/tetratelabs/wabin/wasm"
+)
+
+// decodeCustomSection deserializes the data **not** associated with the "name" key in SectionIDCustom.
+//
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#custom-section%E2%91%A0
+func decodeCustomSection(r *bytes.Reader, name string, limit uint64) (result *wasm.CustomSection, err error) {
+	buf := make([]byte, limit)
+	_, err = r.Read(buf)
+
+	result = &wasm.CustomSection{
+		Name: name,
+		Data: buf,
+	}
+
+	return
+}

--- a/binary/custom_test.go
+++ b/binary/custom_test.go
@@ -1,0 +1,37 @@
+package binary
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/wabin/wasm"
+)
+
+func TestEncodeCustom(t *testing.T) {
+	tests := []struct {
+		name     string
+		custom   *wasm.CustomSection
+		expected []byte
+	}{
+		{
+			name: "custom section",
+			custom: &wasm.CustomSection{
+				Name: "test",
+				Data: []byte("12345"),
+			},
+			expected: []byte{
+				4, 't', 'e', 's', 't',
+				'1', '2', '3', '4', '5',
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			bytes := encodeCustomSection(tc.custom)
+			require.Equal(t, tc.expected, bytes)
+		})
+	}
+}

--- a/binary/custom_test.go
+++ b/binary/custom_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/tetratelabs/wabin/wasm"
 )
 

--- a/binary/decoder_test.go
+++ b/binary/decoder_test.go
@@ -87,17 +87,24 @@ func TestDecodeModule(t *testing.T) {
 		})
 	}
 
-	t.Run("skips custom section", func(t *testing.T) {
+	t.Run("reads custom sections", func(t *testing.T) {
 		input := append(append(Magic, version...),
 			wasm.SectionIDCustom, 0xf, // 15 bytes in this section
 			0x04, 'm', 'e', 'm', 'e',
 			1, 2, 3, 4, 5, 6, 7, 8, 9, 0)
 		m, e := DecodeModule(input, wasm.CoreFeaturesV1)
 		require.NoError(t, e)
-		require.Equal(t, &wasm.Module{}, m)
+		require.Equal(t, &wasm.Module{
+			CustomSections: []*wasm.CustomSection{
+				{
+					Name: "meme",
+					Data: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0},
+				},
+			},
+		}, m)
 	})
 
-	t.Run("skips custom section, but not name", func(t *testing.T) {
+	t.Run("read custom sections and name separately", func(t *testing.T) {
 		input := append(append(Magic, version...),
 			wasm.SectionIDCustom, 0xf, // 15 bytes in this section
 			0x04, 'm', 'e', 'm', 'e',
@@ -109,7 +116,15 @@ func TestDecodeModule(t *testing.T) {
 			's', 'i', 'm', 'p', 'l', 'e')
 		m, e := DecodeModule(input, wasm.CoreFeaturesV1)
 		require.NoError(t, e)
-		require.Equal(t, &wasm.Module{NameSection: &wasm.NameSection{ModuleName: "simple"}}, m)
+		require.Equal(t, &wasm.Module{
+			NameSection: &wasm.NameSection{ModuleName: "simple"},
+			CustomSections: []*wasm.CustomSection{
+				{
+					Name: "meme",
+					Data: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0},
+				},
+			},
+		}, m)
 	})
 	t.Run("data count section disabled", func(t *testing.T) {
 		input := append(append(Magic, version...),

--- a/binary/encoder.go
+++ b/binary/encoder.go
@@ -51,6 +51,9 @@ func EncodeModule(m *wasm.Module) (bytes []byte) {
 			nameSection := append(sizePrefixedName, encodeNameSectionData(m.NameSection)...)
 			bytes = append(bytes, encodeSection(wasm.SectionIDCustom, nameSection)...)
 		}
+		for _, custom := range m.CustomSections {
+			bytes = append(bytes, encodeSection(wasm.SectionIDCustom, encodeCustomSection(custom))...)
+		}
 	}
 	return
 }

--- a/binary/memory.go
+++ b/binary/memory.go
@@ -23,7 +23,7 @@ func decodeMemory(r *bytes.Reader) (*wasm.Memory, error) {
 		mem.IsMaxEncoded = true
 	}
 
-	if min > mem.Max {
+	if mem.Max != 0 && min > mem.Max {
 		return nil, fmt.Errorf("min %d pages (%s) > max %d pages (%s)",
 			min, wasm.PagesToUnitOfBytes(min), mem.Max, wasm.PagesToUnitOfBytes(mem.Max))
 	}

--- a/binary/memory.go
+++ b/binary/memory.go
@@ -21,11 +21,11 @@ func decodeMemory(r *bytes.Reader) (*wasm.Memory, error) {
 	if maxP != nil {
 		mem.Max = *maxP
 		mem.IsMaxEncoded = true
-	}
 
-	if mem.Max != 0 && min > mem.Max {
-		return nil, fmt.Errorf("min %d pages (%s) > max %d pages (%s)",
-			min, wasm.PagesToUnitOfBytes(min), mem.Max, wasm.PagesToUnitOfBytes(mem.Max))
+		if min > mem.Max {
+			return nil, fmt.Errorf("min %d pages (%s) > max %d pages (%s)",
+				min, wasm.PagesToUnitOfBytes(min), mem.Max, wasm.PagesToUnitOfBytes(mem.Max))
+		}
 	}
 
 	return mem, nil

--- a/binary/memory_test.go
+++ b/binary/memory_test.go
@@ -70,7 +70,7 @@ func TestDecodeMemoryType_Errors(t *testing.T) {
 		{
 			name:        "max < min && max == 0",
 			input:       []byte{0x1, 0x80, 0x80, 0x4, 0},
-			expectedErr: "",
+			expectedErr: "min 65536 pages (4 Gi) > max 0 pages (0 Ki)",
 		},
 		{
 			name:        "max < min && max != 0",
@@ -84,11 +84,7 @@ func TestDecodeMemoryType_Errors(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := decodeMemory(bytes.NewReader(tc.input))
-			if tc.expectedErr != "" {
-				require.EqualError(t, err, tc.expectedErr)
-			} else {
-				require.NoError(t, err)
-			}
+			require.EqualError(t, err, tc.expectedErr)
 		})
 	}
 }

--- a/binary/memory_test.go
+++ b/binary/memory_test.go
@@ -68,9 +68,14 @@ func TestDecodeMemoryType_Errors(t *testing.T) {
 		expectedErr string
 	}{
 		{
-			name:        "max < min",
+			name:        "max < min && max == 0",
 			input:       []byte{0x1, 0x80, 0x80, 0x4, 0},
-			expectedErr: "min 65536 pages (4 Gi) > max 0 pages (0 Ki)",
+			expectedErr: "",
+		},
+		{
+			name:        "max < min && max != 0",
+			input:       []byte{0x1, 0x80, 0x80, 0x4, 1},
+			expectedErr: "min 65536 pages (4 Gi) > max 1 pages (64 Ki)",
 		},
 	}
 
@@ -79,7 +84,11 @@ func TestDecodeMemoryType_Errors(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := decodeMemory(bytes.NewReader(tc.input))
-			require.EqualError(t, err, tc.expectedErr)
+			if tc.expectedErr != "" {
+				require.EqualError(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/binary/section.go
+++ b/binary/section.go
@@ -327,3 +327,16 @@ func encodeDataSection(datum []*wasm.DataSegment) []byte {
 	}
 	return encodeSection(wasm.SectionIDData, contents)
 }
+
+// encodeCustomSection encodes a wasm.SectionIDCustom for the data in WebAssembly 1.0 (20191205)
+// Binary Format. This is used for custom sections that are **not** associated with the "name" key.
+//
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#custom-section%E2%91%A0
+func encodeCustomSection(c *wasm.CustomSection) (data []byte) {
+	data = make([]byte, 0, 1+len(c.Name)+len(c.Data))
+	l := byte(len(c.Name))
+	data = append(data, l)
+	data = append(data, []byte(c.Name)...)
+	data = append(data, c.Data...)
+	return
+}

--- a/wasm/counts.go
+++ b/wasm/counts.go
@@ -47,10 +47,11 @@ func (m *Module) importCount(et ExternType) (res uint32) {
 func (m *Module) SectionElementCount(sectionID SectionID) uint32 { // element as in vector elements!
 	switch sectionID {
 	case SectionIDCustom:
+		numCustomSections := uint32(len(m.CustomSections))
 		if m.NameSection != nil {
-			return 1
+			numCustomSections++
 		}
-		return 0
+		return numCustomSections
 	case SectionIDType:
 		return uint32(len(m.TypeSection))
 	case SectionIDImport:

--- a/wasm/module.go
+++ b/wasm/module.go
@@ -154,11 +154,16 @@ type Module struct {
 	// NameSection is set when the SectionIDCustom "name" was successfully decoded from the binary format.
 	//
 	// Note: This is the only SectionIDCustom defined in the WebAssembly Binary Format.
-	// Others are skipped as they are not used in wazero.
+	// Others are read into CustomSections.
 	//
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#name-section%E2%91%A0
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#custom-section%E2%91%A0
 	NameSection *NameSection
+
+	// CustomSections are set when the SectionIDCustom other than "name" were successfully decoded from the binary format.
+	//
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#custom-section%E2%91%A0
+	CustomSections []*CustomSection
 }
 
 // Index is the offset in an index namespace, not necessarily an absolute position in a Module section. This is because
@@ -391,6 +396,12 @@ type NameSection struct {
 	// Note: LocalNames are only used for debugging. At runtime, locals are called based on raw numeric index.
 	// Note: This can be nil for any reason including configuration.
 	LocalNames IndirectNameMap
+}
+
+// CustomSection contains the name and raw data of a custom section.
+type CustomSection struct {
+	Name string
+	Data []byte
 }
 
 // NameMap associates an index with any associated names.


### PR DESCRIPTION
This PR adds support for encoding and decoding the raw data from custom sections to allow for third-party extensions. Without this, I believe reading and rewriting a module will lose custom sections.

Additionally, a tweak was made to max memory size assertion in that if max memory == 0, it should not fail. I'm guessing this is the desired behavior because wabin fails when reading a Wasm module created by TinyGo.

Fixes #3 