### PR TITLE
data segment: encode the right prefix when a constant expression is missing

### DIFF
--- a/binary/data.go
+++ b/binary/data.go
@@ -81,9 +81,13 @@ func decodeDataSegment(r *bytes.Reader, features wasm.CoreFeatures) (*wasm.DataS
 }
 
 func encodeDataSegment(d *wasm.DataSegment) (ret []byte) {
-	// Currently multiple memories are not supported.
-	ret = append(ret, leb128.EncodeInt32(0)...)
-	ret = append(ret, encodeConstantExpression(d.OffsetExpression)...)
+	if d.OffsetExpression == nil {
+		ret = append(ret, leb128.EncodeInt32(int32(dataSegmentPrefixPassive))...)
+	} else {
+		// Currently multiple memories are not supported.
+		ret = append(ret, leb128.EncodeInt32(int32(dataSegmentPrefixActive))...)
+		ret = append(ret, encodeConstantExpression(d.OffsetExpression)...)
+	}
 	ret = append(ret, leb128.EncodeUint32(uint32(len(d.Init)))...)
 	ret = append(ret, d.Init...)
 	return

--- a/binary/data_test.go
+++ b/binary/data_test.go
@@ -128,3 +128,48 @@ func Test_decodeDataSegment(t *testing.T) {
 		})
 	}
 }
+
+func Test_encodeDataSegment(t *testing.T) {
+	tests := []struct {
+		in       *wasm.DataSegment
+		exp      []byte
+		features wasm.CoreFeatures
+		expErr   string
+	}{
+		{
+			in: &wasm.DataSegment{
+				OffsetExpression: &wasm.ConstantExpression{
+					Opcode: wasm.OpcodeI32Const,
+					Data:   []byte{0x1},
+				},
+				Init: []byte{0xf, 0xf},
+			},
+			exp: []byte{0x0,
+				// Const expression.
+				wasm.OpcodeI32Const, 0x1, wasm.OpcodeEnd,
+				// Two initial data.
+				0x2, 0xf, 0xf,
+			},
+			features: wasm.CoreFeatureBulkMemoryOperations,
+		},
+		{
+			exp: []byte{0x1, // Passive data segment without memory index and const expr.
+				// Two initial data.
+				0x2, 0xf, 0xf,
+			},
+			in: &wasm.DataSegment{
+				OffsetExpression: nil,
+				Init:             []byte{0xf, 0xf},
+			},
+			features: wasm.CoreFeatureBulkMemoryOperations,
+		},
+	}
+
+	for i, tt := range tests {
+		tc := tt
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			actual := encodeDataSegment(tc.in)
+			require.Equal(t, tc.exp, actual)
+		})
+	}
+}


### PR DESCRIPTION
closes #5

as explained in https://github.com/tetratelabs/wabin/issues/5#issuecomment-1435590361:

> indeed we should make a distinction between 0x0 and 0x1; i.e. if `OffsetExpression` is nil, we may assume the mode to be passive and use `0x1`
> 
> While for 0x2 I don't know if it's worth supporting at this time. If I understand the spec right, 0x2 is only for the cases where the memory index is >=0, i.e. even though 0 is a valid value, it only makes sense to use when it is >0; however, the spec also says:
> 
> > In the current version of WebAssembly, at most one memory may be defined or imported in a single module, so all valid [active](https://www.w3.org/TR/wasm-core-2/syntax/modules.html#syntax-data) data segments have a `memory` value of 0.
> 
> If I were to add support for arbitrary memory indices, then I would have to add a field to `wasm.DataSegment` to indicate the memory index and then possibly return an `error` when it's >0; which in turn requires a change of signature in `encodeDataSegment`.
> 
> So, for the time being, I would only do the simple thing and correctly encode passive segments as 0x1, otherwise defaulting to 0x0
> 

